### PR TITLE
Web 1146 login tests new expect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
           cron: "0 8 * * *"
     jobs:
       - test

--- a/pageobjects/loginPage.js
+++ b/pageobjects/loginPage.js
@@ -10,11 +10,6 @@ module.exports = {
         logo: 'img[alt="Tidepool"]',
       },
       commands: [{
-        elementsPresent() {
-          return this
-            .assert.visible('@signupLink', 'signup link visible and references correct link')
-            .assert.visible('@logo', 'Tidepool logo is visible');
-        },
       }],
     },
     loginForm: {
@@ -30,17 +25,13 @@ module.exports = {
         },
       },
       commands: [{
-        elementsPresent() {
-          return this
-            .assert.visible('@forgotPasswordLink', 'forgot password link visible and references correct link');
-        },
         loginDsa(username, password) {
           return this
             .setValue('@usernameInput', username)
             .setValue('@passwordInput', password)
             .click('@rememberChk')
             .click('@loginBtn')
-            .api.assert.urlContains('data', 'successful login');
+            .api.expect.url().to.contain('data');
         },
       }],
     },
@@ -55,15 +46,6 @@ module.exports = {
         jdrfLink: 'a[href="http://jdrf.org/"]',
       },
       commands: [{
-        elementsPresent() {
-          return this
-            .assert.visible('@twitterLogo', 'Twitter logo visible and references correct link')
-            .assert.visible('@facebookLogo', 'facebook logo visible and references correct link')
-            .assert.visible('@mobileLink', 'mobile link visible and references correct link')
-            .assert.visible('@supportLink', 'support link ivisible and references correct link')
-            .assert.visible('@termsLink', 'terms link visible and references correct link')
-            .assert.visible('@jdrfLink', 'JDRF link visible and references correct link');
-        },
       }],
     },
   },

--- a/tests/ui/loginPageUITests.js
+++ b/tests/ui/loginPageUITests.js
@@ -1,13 +1,30 @@
 module.exports = {
   '@tags': ['parallel'],
-  'UI Elements Present'(browser) {
+  'Verify nav elements present'(browser) {
     const loginPage = browser.page.loginPage();
     const pageNav = loginPage.section.navigation;
+    loginPage.loadPage();
+    pageNav.waitForElementVisible('@signupLink', browser.globals.elementTimeout);
+    pageNav.expect.element('@logo').to.be.visible;
+  },
+  'Verify login Form elements present'(browser) {
+    const loginPage = browser.page.loginPage();
     const loginForm = loginPage.section.loginForm;
+    loginPage.loadPage();
+    loginForm.waitForElementVisible('@usernameInput', browser.globals.elementTimeout);
+    loginForm.expect.element('@passwordInput').to.be.visible;
+    loginForm.expect.element('@rememberChk').to.be.visible;
+    loginForm.expect.element('@loginBtn').to.be.visible;
+  },
+  'Verify footer elements present'(browser) {
+    const loginPage = browser.page.loginPage();
     const footer = loginPage.section.footer;
     loginPage.loadPage();
-    pageNav.elementsPresent();
-    loginForm.elementsPresent();
-    footer.elementsPresent();
+    footer.waitForElementVisible('@twitterLogo', browser.globals.elementTimeout);
+    footer.expect.element('@facebookLogo').to.be.visible;
+    footer.expect.element('@mobileLink').to.be.visible;
+    footer.expect.element('@supportLink').to.be.visible;
+    footer.expect.element('@termsLink').to.be.visible;
+    footer.expect.element('@jdrfLink').to.be.visible;
   },
 };


### PR DESCRIPTION
uses nightwatch new expect api to provide better seperation of concerns between page objects and tests. (ci will not pass qa1, this is expected while the new 1.45 r.c. is on there).