### PR TITLE
Web 1147 add dev and int environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ jobs:
       - run: 
           name: Run prd Tests
           command: npm run testprdSeq
+      - run: 
+          name: Run int Tests
+          command: npm run testintSeq
 
 workflows:
   commit-workflow:

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -56,6 +56,32 @@ module.exports = {
         'browserstack.debug': 'true',
       },
     },
+    dev1_chrome: {
+      launch_url: 'https://dev1.dev.tidepool.org',
+      desiredCapabilities: {
+        os: 'Windows',
+        osVersion: '10',
+        browserName: 'chrome',
+        browserVersion: 'latest',
+        resolution: '1366x768',
+        build: `DEV1_CHROME ${dayjs().format('YYYY-MM-DD h:mm:ss A')}`,
+        'browserstack.networkLogs': 'true',
+        'browserstack.debug': 'true',
+      },
+    },
+    int_chrome: {
+      launch_url: 'https://int-app.tidepool.org',
+      desiredCapabilities: {
+        os: 'Windows',
+        osVersion: '10',
+        browserName: 'chrome',
+        browserVersion: 'latest',
+        resolution: '1366x768',
+        build: `INT_CHROME ${dayjs().format('YYYY-MM-DD h:mm:ss A')}`,
+        'browserstack.networkLogs': 'true',
+        'browserstack.debug': 'true',
+      },
+    },
   },
   /*
     When we're ready to use multi-browser testing we can uncomment these

--- a/package.json
+++ b/package.json
@@ -4,13 +4,17 @@
   "description": "Tidepool UI Testing with nightwatch and browserstack",
   "main": "index.js",
   "scripts": {
-    "testParallel": "nightwatch --tag parallel --env qa2_chrome,qa1_chrome,prd_chrome",
+    "testParallel": "nightwatch --tag parallel --env qa2_chrome,qa1_chrome,prd_chrome,int_chrome",
     "testqa2Seq": "nightwatch --tag sequential --env qa2_chrome",
     "testqa1Seq": "nightwatch --tag sequential --env qa1_chrome",
     "testprdSeq": "nightwatch --tag sequential --env prd_chrome",
+    "testintSeq": "nightwatch --tag sequential --env int_chrome",
+    "testdev1Seq": "nightwatch --tag sequential --env dev1_chrome",
     "testqa2All": "nightwatch --env qa2_chrome",
     "testqa1All": "nightwatch --env qa1_chrome",
-    "testprdAll": "nightwatch --env prd_chrome"
+    "testprdAll": "nightwatch --env prd_chrome",
+    "testintAll": "nightwatch --env int_chrome",
+    "testdev1All": "nightwatch --env dev1_chrome"
   },
   "scriptsComments": {
     "testParallel": "Executes tests that are able to run in parallel on all environments",


### PR DESCRIPTION
Added int and dev environment to the capabilities. after speaking with the backend team, we do not need the tests to run on a specified cadence on dev1, since the environment is particularly volatile. However we still need the ability to run the tests on demand for dev1 by QA so we've added that capability here for dev1. The INT environment will run on the same cadence as the other environments.