### PR TITLE
Web 1393 fix environment references

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -33,16 +33,12 @@ module.exports = {
       },
     },
 
-    default: {
-      launch_url: 'https://app.tidepool.org',
-    },
-
     qa2chrome: {
       extends: 'browserstack',
+      launch_url: 'https://qa2.development.tidepool.org',
       desiredCapabilities: {
         browserName: 'chrome',
         browserVersion: 'latest',
-        launch_url: 'https://qa2.development.tidepool.org',
         os: 'Windows',
         osVersion: '10',
         resolution: '1366x768',
@@ -52,10 +48,10 @@ module.exports = {
 
     qa1chrome: {
       extends: 'browserstack',
+      launch_url: 'https://qa1.development.tidepool.org',
       desiredCapabilities: {
         browserName: 'chrome',
         browserVersion: 'latest',
-        launch_url: 'https://qa1.development.tidepool.org',
         os: 'Windows',
         osVersion: '10',
         resolution: '1366x768',
@@ -65,10 +61,10 @@ module.exports = {
 
     intchrome: {
       extends: 'browserstack',
+      launch_url: 'https://int-app.tidepool.org',
       desiredCapabilities: {
         browserName: 'chrome',
         browserVersion: 'latest',
-        launch_url: 'https://int-app.tidepool.org',
         os: 'Windows',
         osVersion: '10',
         resolution: '1366x768',
@@ -79,10 +75,10 @@ module.exports = {
 
     prdchrome: {
       extends: 'browserstack',
+      launch_url: 'https://app.tidepool.org',
       desiredCapabilities: {
         browserName: 'chrome',
         browserVersion: 'latest',
-        launch_url: 'https://app.tidepool.org',
         os: 'Windows',
         osVersion: '10',
         resolution: '1366x768',
@@ -92,10 +88,10 @@ module.exports = {
 
     dev1chrome: {
       extends: 'browserstack',
+      launch_url: 'https://dev1.dev.tidepool.org',
       desiredCapabilities: {
         browserName: 'chrome',
         browserVersion: 'latest',
-        launch_url: 'https://dev1.dev.tidepool.org',
         os: 'Windows',
         osVersion: '10',
         resolution: '1366x768',

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Tidepool UI Testing with nightwatch and browserstack",
   "main": "index.js",
   "scripts": {
-    "testParallel": "nightwatch --tag parallel --env qa2chrome,qa1chrome,prdchrome,intchrome",
+    "testParallel": "nightwatch --tag parallel --env qa2chrome,qa1chrome,prdchrome",
     "testqa2Seq": "nightwatch --tag sequential --env qa2chrome",
     "testqa1Seq": "nightwatch --tag sequential --env qa1chrome",
     "testprdSeq": "nightwatch --tag sequential --env prdchrome",

--- a/pageobjects/loginPage.js
+++ b/pageobjects/loginPage.js
@@ -31,7 +31,7 @@ module.exports = {
             .setValue('@passwordInput', password)
             .click('@rememberChk')
             .click('@loginBtn')
-            .api.expect.url().to.contain('data');
+            .waitForElementVisible('#tidelineMain', 10000);
         },
       }],
     },


### PR DESCRIPTION
We noticed that the default_url key was not being used by nightwatch. Moved it out of the browserstack desired capabilities object into the parent environment object. 