### PR TITLE
[AUTO-203] Update basics view selectors

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -28,7 +28,6 @@ module.exports = {
         local: 'false',
         userName: process.env.BROWSERSTACK_USER,
         accessKey: process.env.BROWSERSTACK_KEY,
-        'browserstack.networkLogs': 'true',
         'browserstack.debug': 'true',
       },
     },
@@ -43,6 +42,7 @@ module.exports = {
         osVersion: '10',
         resolution: '1366x768',
         build: `QA2_CHROME ${dayjs().format('YYYY-MM-DD h:mm:ss A')}`,
+        'browserstack.networkLogs': 'true',
       },
     },
 
@@ -56,6 +56,7 @@ module.exports = {
         osVersion: '10',
         resolution: '1366x768',
         build: `QA1_CHROME ${dayjs().format('YYYY-MM-DD h:mm:ss A')}`,
+        'browserstack.networkLogs': 'true',
       },
     },
 
@@ -83,6 +84,7 @@ module.exports = {
         osVersion: '10',
         resolution: '1366x768',
         build: `PRD_CHROME ${dayjs().format('YYYY-MM-DD h:mm:ss A')}`,
+        'browserstack.networkLogs': 'true',
       },
     },
 

--- a/pageobjects/basicsPage.js
+++ b/pageobjects/basicsPage.js
@@ -194,7 +194,7 @@ module.exports = {
           locateStrategy: 'xpath',
         },
         bottomOfDashboard: {
-          selector: '//button[text()="Refresh"]',
+          selector: '//*[contains(@class,"refresh")]',
           locateStrategy: 'xpath',
         },
         basalEvents: {

--- a/pageobjects/commonElementsPage.js
+++ b/pageobjects/commonElementsPage.js
@@ -55,7 +55,7 @@ module.exports = {
       selector: '#app',
       elements: {
         refresh: {
-          selector: '//button[text()="Refresh"]',
+          selector: '//*[contains(@class,"refresh")]',
           locateStrategy: 'xpath',
         },
         twitter: '#twitter',


### PR DESCRIPTION
- Different selector for refresh button
-  Browserstack has confirmed that using their service to gather network logs (browsermob) doesn’t support TLSv1.3 . I  disabled the network logging through browserstack for now for environments that require TLSv1.3, so we can run the tests. We can look into using nightwatch itself to gather network logs when we switch to nightwatch 2.0.