### PR TITLE
chore: Update browser-tools orb to version 1.5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   node: circleci/node@5.0.2
-  browser-tools: circleci/browser-tools@1.4.8
+  browser-tools: circleci/browser-tools@1.5.1
   slack: circleci/slack@4.1
 parameters:
   testEnvironment:


### PR DESCRIPTION
Fixing problems with Firefox - https://app.circleci.com/pipelines/github/tidepool-org/WebUITests/1705/workflows/20701a96-e01f-4909-a80a-0e8f6e05a0bc/jobs/2015

Others have same issue - solution was solved here - https://discuss.circleci.com/t/browser-tools-orb-failing-for-latest-firefox-version/52721/2