### PR TITLE
chore: Remove JDRF footer element references

### DIFF
--- a/pageobjects/commonElementsPage.js
+++ b/pageobjects/commonElementsPage.js
@@ -82,7 +82,6 @@ module.exports = {
         facebook: '#facebook',
         support: '#support',
         termsOfUse: '#legal',
-        jdrf: '#jdrf',
       },
       commands: [{
       }],

--- a/tests/ui/basicsPageUITests.js
+++ b/tests/ui/basicsPageUITests.js
@@ -120,7 +120,6 @@ module.exports = {
     footer.expect.element('@facebook').to.be.visible;
     footer.expect.element('@support').to.be.visible;
     footer.expect.element('@termsOfUse').to.be.visible;
-    footer.expect.element('@jdrf').to.be.visible;
   },
   'verify sidebar and BGM agg stat elements present'(browser) {
     const basics = browser.page.basicsPage();


### PR DESCRIPTION
WEB-2770 + WEB-3003.

https://tidepool.atlassian.net/browse/WEB-3003

This is just draft due to:
2. Resolved ~[WEB-2770](https://tidepool.atlassian.net/browse/WEB-2770) - I asked question about element with id `twitter` - if we want to rename it to `x.com` or similar.~
3. [BACK-3399](https://tidepool.atlassian.net/browse/BACK-3399) - we still have JDRF in login page. After implementing this changes, we should edit our tests as well. 



[WEB-2770]: https://tidepool.atlassian.net/browse/WEB-2770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BACK-3399]: https://tidepool.atlassian.net/browse/BACK-3399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ