### PR TITLE
Update: edit-clinic-addres

### DIFF
--- a/page-objects/clinician/ClinicCreationPage.ts
+++ b/page-objects/clinician/ClinicCreationPage.ts
@@ -60,8 +60,8 @@ export default class ClinicCreationPage {
     this.websiteInput = page.getByLabel('Website (optional)');
 
     // Blood glucose units radio buttons
-    this.mgdlRadio = page.getByRole('radio', { name: 'mg/dL' });
-    this.mmolRadio = page.getByRole('radio', { name: 'mmol/L' });
+    this.mgdlRadio = page.locator('label').filter({ hasText: 'mg/dL' });
+    this.mmolRadio = page.locator('label').filter({ hasText: 'mmol/L' });
 
     // Acknowledgement checkbox
     this.adminAcknowledgeCheckbox = page.getByRole('checkbox', { name: 'admin' });

--- a/page-objects/clinician/ClinicianNavigation.ts
+++ b/page-objects/clinician/ClinicianNavigation.ts
@@ -1,16 +1,23 @@
 import { Locator, Page } from '@playwright/test';
 
-// Workspace verification interface (matching PatientNavigation format)
-export interface WorkspaceNavVerify {
-  name: string;
-  link: Locator;
-  verifyURL: string;
-  verifyElement: Locator;
-}
+// List of workspace display names
+export const WORKSPACE_NAMES = [
+  'Admin Clinic (Base)',
+  'Admin Clinic (Enterprise)',
+  'Admin Clinic (Essential)',
+  'Admin Clinic (Professional)',
+  'Member Clinic (Base)',
+  'Member Clinic (Enterprise)',
+  'Member Clinic (Essential)',
+  'Member Clinic (Professional)',
+] as const;
 
-// Page navigation verification interface (matching PatientNavigation format)
-export interface PageNavVerify {
-  name: string;
+// Key generator for workspace names
+const workspaceKey = (name: string) => name.replace(/[^a-zA-Z0-9]/g, '');
+export type WorkspaceKey = ReturnType<typeof workspaceKey>;
+
+// Unified navigation verification interface
+export interface NavVerify {
   link: Locator;
   verifyURL: string;
   verifyElement: Locator;
@@ -18,126 +25,64 @@ export interface PageNavVerify {
 }
 
 export default class ClinicianNav {
-  readonly page: Page;
-
-  readonly workspaces: Record<
-    | 'AdminClinicBase'
-    | 'AdminClinicEnterprise'
-    | 'MemberClinicBase'
-    | 'MemberClinicEnterprise'
-    | 'NonMemberClinicBase'
-    | 'NonMemberClinicEnterprise'
-    | 'PartnerClinicBase'
-    | 'PartnerClinicEnterprise',
-    WorkspaceNavVerify
-  >;
+  readonly workspaces: Record<WorkspaceKey, NavVerify>;
 
   readonly pages: Record<
-    'PatientList' | 'WorkspaceSettings' | 'ManageWorkspaces' | 'AddPatient' | 'Profile' | 'ProfileEdit',
-    PageNavVerify
+    | 'PatientList'
+    | 'WorkspaceSettings'
+    | 'ManageWorkspaces'
+    | 'AddPatient'
+    | 'Profile'
+    | 'ProfileEdit',
+    NavVerify
   >;
 
   constructor(page: Page) {
-    this.page = page;
+    if (!page || typeof page.getByRole !== 'function') {
+      throw new Error(
+        '[ClinicianNav] Invalid Playwright Page object passed to ClinicianNav constructor.',
+      );
+    }
 
-    // Define hardcoded workspace configurations (matching PatientNavigation approach)
-    this.workspaces = {
-      AdminClinicBase: {
-        name: 'Admin Clinic (Base)',
-        link: page
-          .locator('#navigationMenu button')
-          .filter({ hasText: 'Admin Clinic (Base) Workspace' }),
-        verifyURL: 'clinic-workspace',
-        verifyElement: page.locator('h4').filter({ hasText: 'Admin Clinic (Base)' }),
-      },
-      AdminClinicEnterprise: {
-        name: 'Admin Clinic (Enterprise)',
-        link: page
-          .locator('#navigationMenu button')
-          .filter({ hasText: 'Admin Clinic (Enterprise) Workspace' }),
-        verifyURL: 'clinic-workspace',
-        verifyElement: page.locator('h4').filter({ hasText: 'Admin Clinic (Enterprise)' }),
-      },
-      MemberClinicBase: {
-        name: 'Member Clinic (Base)',
-        link: page
-          .locator('#navigationMenu button')
-          .filter({ hasText: 'Member Clinic (Base) Workspace' }),
-        verifyURL: 'clinic-workspace',
-        verifyElement: page.locator('h4').filter({ hasText: 'Member Clinic (Base)' }),
-      },
-      MemberClinicEnterprise: {
-        name: 'Member Clinic (Enterprise)',
-        link: page
-          .locator('#navigationMenu button')
-          .filter({ hasText: 'Member Clinic (Enterprise) Workspace' }),
-        verifyURL: 'clinic-workspace',
-        verifyElement: page.locator('h4').filter({ hasText: 'Member Clinic (Enterprise)' }),
-      },
-      NonMemberClinicBase: {
-        name: 'Non-Member Clinic (Base)',
-        link: page
-          .locator('#navigationMenu button')
-          .filter({ hasText: 'Non-Member Clinic (Base) Workspace' }),
-        verifyURL: 'clinic-workspace',
-        verifyElement: page.locator('h4').filter({ hasText: 'Non-Member Clinic (Base)' }),
-      },
-      NonMemberClinicEnterprise: {
-        name: 'Non-Member Clinic (Enterprise)',
-        link: page
-          .locator('#navigationMenu button')
-          .filter({ hasText: 'Non-Member Clinic (Enterprise) Workspace' }),
-        verifyURL: 'clinic-workspace',
-        verifyElement: page.locator('h4').filter({ hasText: 'Non-Member Clinic (Enterprise)' }),
-      },
-      PartnerClinicBase: {
-        name: 'Partner Clinic (Base)',
-        link: page
-          .locator('#navigationMenu button')
-          .filter({ hasText: 'Partner Clinic (Base) Workspace' }),
-        verifyURL: 'clinic-workspace',
-        verifyElement: page.locator('h4').filter({ hasText: 'Partner Clinic (Base)' }),
-      },
-      PartnerClinicEnterprise: {
-        name: 'Partner Clinic (Enterprise)',
-        link: page
-          .locator('#navigationMenu button')
-          .filter({ hasText: 'Partner Clinic (Enterprise) Workspace' }),
-        verifyURL: 'clinic-workspace',
-        verifyElement: page.locator('h4').filter({ hasText: 'Partner Clinic (Enterprise)' }),
-      },
-    };
+    const WORKSPACE_VERIFY_URL = 'clinic-workspace';
+    this.workspaces = Object.fromEntries(
+      WORKSPACE_NAMES.map(name => [
+        workspaceKey(name),
+        {
+          link: page
+            .locator('.workspace-item-clinic')
+            .filter({ hasText: name })
+            .getByRole('button', { name: 'Go To Workspace' }),
+          verifyURL: WORKSPACE_VERIFY_URL,
+          verifyElement: page.locator('h4').filter({ hasText: name }),
+        },
+      ]),
+    ) as Record<WorkspaceKey, NavVerify>;
 
-    // Define clinician page navigation (matching PatientNavigation format)
     this.pages = {
       PatientList: {
-        name: 'PatientList',
-        link: page.getByRole('link', { name: 'Patients' }),
+        link: page.getByRole('tab', { name: 'Patient List' }),
         verifyURL: 'clinic-workspace/patients',
         verifyElement: page.getByRole('heading', { name: 'Patients' }),
       },
       WorkspaceSettings: {
-        name: 'WorkspaceSettings',
-        link: page.getByRole('link', { name: 'Workspace Settings' }),
+        link: page.getByRole('button', { name: 'Workspace Settings' }),
         verifyURL: 'clinic-workspace/workspace/settings',
         verifyElement: page.getByRole('heading', { name: 'Workspace Settings' }),
       },
       ManageWorkspaces: {
-        name: 'ManageWorkspaces',
         link: page
           .locator('#navigationMenu button.navigation-menu-option')
           .filter({ hasText: 'Manage Workspaces' }),
         verifyURL: 'workspaces',
-        verifyElement: page.getByText('Welcome To Tidepool'), // Should land back on the workspace selection page
+        verifyElement: page.getByText('Welcome To Tidepool'),
       },
       AddPatient: {
-        name: 'AddPatient',
         link: page.getByRole('button', { name: 'Add Patient' }),
         verifyURL: 'clinic-workspace/patients/add',
         verifyElement: page.getByRole('heading', { name: 'Add Patient' }),
       },
       Profile: {
-        name: 'Profile',
         link: page
           .getByRole('button', { name: 'Patient Profile Profile' })
           .or(page.getByRole('tab', { name: 'Profile' }))
@@ -149,7 +94,6 @@ export default class ClinicianNav {
           .or(page.getByRole('button', { name: 'Edit Profile' })),
       },
       ProfileEdit: {
-        name: 'ProfileEdit',
         link: page
           .getByRole('button', { name: 'Edit' })
           .or(page.getByRole('button', { name: 'Edit Profile' })),

--- a/page-objects/clinician/WorkspaceSettingsPage.ts
+++ b/page-objects/clinician/WorkspaceSettingsPage.ts
@@ -1,19 +1,33 @@
 import { Locator, Page } from '@playwright/test';
+import ClinicCreationPage from './ClinicCreationPage';
 
-export default class ClinicAdminPage {
-  readonly clinicDetailsHeader: Locator;
+export default class WorkspaceSettingsPage {
+  // Workspace Settings
+  readonly workspaceSettingsHeader: Locator;
+
+  readonly workspaceDetailsSection: Locator;
 
   readonly editDetailsButton: Locator;
+
+  readonly clinicName: Locator;
+
+  readonly clinicType: Locator;
+
+  readonly clinicAddress: Locator;
+
+  readonly clinicWebsite: Locator;
+
+  readonly clinicPreferredBloodGlucose: Locator;
+
+  // Edit Workspace Settings Modal
+
+  readonly editWorkspaceModal: Locator;
 
   readonly editClinicModal: Locator;
 
   readonly editClinicModalTitle: Locator;
 
-  readonly addressInput: Locator;
-
   readonly saveChangesButton: Locator;
-
-  readonly clinicDetailsSection: Locator; // The section displaying clinic details on the main page
 
   url = '/clinic-admin';
 
@@ -23,25 +37,27 @@ export default class ClinicAdminPage {
 
   constructor(page: Page) {
     this.page = page;
-    this.clinicDetailsHeader = page.getByText('Workspace Settings');
-    // Assuming the edit button is specifically associated with the details section
-    this.editDetailsButton = page.getByRole('button', { name: 'Edit' });
+    // Workspace Settings
+    this.workspaceSettingsHeader = page.getByText('Workspace Settings');
+    this.workspaceDetailsSection = page.locator('#clinicWorkspaceDetails');
+    this.editDetailsButton = page.locator('#clinic-profile-edit-trigger');
+    this.clinicName = page.locator('#clinicName');
+    this.clinicType = page.locator('#clinicType').filter({ hasText: 'Type' });
+    this.clinicAddress = page.locator('#clinicAddress');
+    this.clinicWebsite = page.locator('#clinicWebsite');
+    this.clinicPreferredBloodGlucose = page.locator('#clinicPreferredBloodGlucoseUnits');
+
+    this.editWorkspaceModal = page.getByRole('dialog');
     this.editClinicModal = page.getByRole('dialog'); // General dialog selector
     this.editClinicModalTitle = this.editClinicModal.getByRole('heading', {
       name: 'Edit Workspace Details',
     });
-    this.addressInput = this.editClinicModal.getByLabel('Address', { exact: true }); // Use exact label match
     this.saveChangesButton = this.editClinicModal.getByRole('button', { name: 'Save Changes' });
     // Assuming the details are within a specific container section related to the header
-    this.clinicDetailsSection = page.locator('div:has(> span:text-is("Workspace Settings")) + div');
   }
 
-  /**
-   * Waits for essential elements of the Clinic Admin page to be loaded.
-   */
   async waitForLoadState(): Promise<void> {
     await this.page.waitForLoadState(); // Wait for base elements like header/footer
-    await this.clinicDetailsHeader.waitFor({ state: 'visible', timeout: 40000 });
-    await this.editDetailsButton.waitFor({ state: 'visible', timeout: 10000 });
+    await this.workspaceSettingsHeader.waitFor({ state: 'visible', timeout: 40000 });
   }
 }

--- a/tests/clinician/edit-clinic-address.spec.ts
+++ b/tests/clinician/edit-clinic-address.spec.ts
@@ -1,50 +1,128 @@
-import { expect, test } from '@fixtures/base';
-import ClinicAdminPage from '@pom/clinician/WorkspaceSettingsPage';
-import WorkspacesPage from '@pom/clinician/WorkspacesPage';
+import { expect } from '@fixtures/base';
+import { test, ALL_WORKSPACE_KEYS } from '@fixtures/clinic-helpers';
+import { TEST_TAGS, createValidatedTags } from '@fixtures/test-tags';
+import WorkspaceSettingsPage from '@pom/clinician/WorkspaceSettingsPage';
+import ClinicCreationPage from '@pom/clinician/ClinicCreationPage';
 
-test.describe('Edit clinic address', () => {
-  const newAddress = `123 Test Street ${Date.now()}`; // Unique address for test run
-  let clinicAdminPage: ClinicAdminPage;
-  let workspacesPage: WorkspacesPage;
+import type { WorkspaceKey } from '@pom/clinician/ClinicianNavigation';
 
-  test.beforeEach(async ({ page }) => {
-    clinicAdminPage = new ClinicAdminPage(page);
-    workspacesPage = new WorkspacesPage(page);
+ALL_WORKSPACE_KEYS.forEach((workspace: WorkspaceKey) => {
+  test.describe('Clinic admin given edit permissions to Workspace Details. Clinic Members have view only access', () => {
+    test(
+      `should allow navigation to workspace details and edit workspace: "[${workspace}]"`,
+      {
+        tag: createValidatedTags([TEST_TAGS.CLINICIAN, TEST_TAGS.UI, TEST_TAGS.MEDIUM]),
+      },
+      async ({ page }) => {
+        // Step 1: Log in to clinician account and setup network capture
+        await test.step('Given clinician has been logged in', async () => {
+          await test.clinician.setup(page);
+        });
 
-    await test.step('Given user has navigated to the Clinic Admin page', async () => {
-      await workspacesPage.goto();
-      await workspacesPage.visitFirstClinic();
-      await page.goto('/clinic-admin');
-      await clinicAdminPage.waitForLoadState(); // Wait for clinic admin page elements
-      await clinicAdminPage.clinicDetailsHeader.waitFor({ state: 'visible' });
-    });
-  });
+        // Step 2: Navigate to currently tested workspace
+        await test.step(`When user navigates to workspace ${workspace}`, async () => {
+          await test.clinician.navigateToWorkspace(workspace, page);
+        });
 
-  test('should successfully edit the clinic address', async ({ page }) => {
-    await test.step('When user clicks the "Edit" button for workspace details', async () => {
-      await clinicAdminPage.editDetailsButton.click();
-      await clinicAdminPage.editClinicModal.waitFor({ state: 'visible' });
-    });
+        // Step 3: Navigate to workspace settings
+        await test.step('When user navigates to workspace settings', async () => {
+          await test.clinician.navigateTo('WorkspaceSettings', page);
+        });
 
-    await test.step('Then user sees the modal for Editing workspace details', async () => {
-      await expect(clinicAdminPage.editClinicModalTitle).toBeVisible();
-      await expect(clinicAdminPage.addressInput).toBeVisible();
-    });
+        // Create workspace settings page
+        const workspaceSettings = new WorkspaceSettingsPage(page);
 
-    await test.step('When user changes the address', async () => {
-      await clinicAdminPage.addressInput.fill(newAddress);
-    });
+        // Step 4a: Workspace details view from by a member user does not have edit button
+        if (workspace.includes('Member')) {
+          await test.step('Then edit button is not present for Member users', async () => {
+            await expect(workspaceSettings.editDetailsButton).toBeHidden();
+          });
+          return;
+        }
 
-    await test.step('When user clicks on "Save changes"', async () => {
-      await clinicAdminPage.saveChangesButton.click();
-      await clinicAdminPage.editClinicModal.waitFor({ state: 'hidden' }); // Wait for modal to close
-    });
+        // Step 4b: Workspace details view from admin user has edit button and it is clickable
+        await test.step('Then edit button is present and clickable for Admin users', async () => {
+          await expect(workspaceSettings.editDetailsButton).toBeVisible();
+          await workspaceSettings.editDetailsButton.click();
+          await page.waitForTimeout(500);
+        });
 
-    await test.step('Then user sees the updated address on the page', async () => {
-      // Wait for the details section to potentially update
-      await page.waitForTimeout(1000); // Small wait for potential DOM update
-      const detailsText = clinicAdminPage.clinicDetailsSection;
-      await expect(detailsText).toContainText(newAddress);
-    });
+        // Create clinic creation page
+        const clinicCreation = new ClinicCreationPage(page);
+        // Define clinic details for compare and reset reasons
+        const currentClinicName = await clinicCreation.clinicNameInput.inputValue();
+        const currentDate = Date.now();
+        const newAddress = `Street # ${currentDate}`;
+        const newCity = `City ${currentDate}`;
+        const newZipCode = `Zip ${currentDate}`;
+        const newWebsite = `https://www.clinic-${currentDate}.com`;
+
+        // Step 5: Edit all Workspace details fields
+        await test.step('When user edits all workspace details fields', async () => {
+          await clinicCreation.fillClinicForm({
+            clinicName: `${currentClinicName} Edited`,
+            clinicType: 'Healthcare System',
+            state: 'Oregon',
+            address: newAddress,
+            city: newCity,
+            zipCode: newZipCode,
+            website: newWebsite,
+          });
+          await clinicCreation.mmolRadio.check({ force: true });
+        });
+
+        // Step 6: Save changes
+        await test.step('When user saves changes', async () => {
+          await workspaceSettings.saveChangesButton.click();
+          await page.waitForTimeout(500);
+        });
+
+        // Step 7: Confirm changes
+        await test.step('Then modal is dismissed and workspace details are updated', async () => {
+          await workspaceSettings.waitForLoadState();
+          await expect(workspaceSettings.clinicName).toHaveText(`${currentClinicName} Edited`);
+          await expect(workspaceSettings.clinicType).toContainText('Healthcare System');
+          await expect(workspaceSettings.clinicAddress).toContainText(newAddress);
+          await expect(workspaceSettings.clinicAddress).toContainText('OR');
+          await expect(workspaceSettings.clinicAddress).toContainText(newCity);
+          await expect(workspaceSettings.clinicAddress).toContainText(newZipCode);
+          await expect(workspaceSettings.clinicWebsite).toContainText(newWebsite);
+          await expect(workspaceSettings.clinicPreferredBloodGlucose).toContainText('mmol/L');
+        });
+
+        // Step 8: Click edit details button
+        await test.step('When user clicks edit details button', async () => {
+          await workspaceSettings.editDetailsButton.click();
+          await page.waitForTimeout(500);
+        });
+
+        // Step 9: Return clinic details to default values for navigation reasons/reset
+        await test.step('When user resets Workspace details fields', async () => {
+          await clinicCreation.fillClinicForm({
+            clinicName: currentClinicName,
+          });
+          await clinicCreation.mgdlRadio.check({ force: true });
+        });
+
+        // Step 10: Save changes
+        await test.step('When user saves changes', async () => {
+          await workspaceSettings.saveChangesButton.click();
+          await page.waitForTimeout(500);
+        });
+
+        // Step 11: Confirm reset to previous state
+        await test.step('Then modal is dismissed and workspace details return to default state', async () => {
+          await workspaceSettings.waitForLoadState();
+          await expect(workspaceSettings.clinicName).toHaveText(currentClinicName);
+          await expect(workspaceSettings.clinicType).toContainText('Provider Practice');
+          await expect(workspaceSettings.clinicAddress).toContainText('123 Test Street');
+          await expect(workspaceSettings.clinicAddress).toContainText('CA');
+          await expect(workspaceSettings.clinicAddress).toContainText('Test City');
+          await expect(workspaceSettings.clinicAddress).toContainText('12345');
+          await expect(workspaceSettings.clinicWebsite).toContainText(newWebsite);
+          await expect(workspaceSettings.clinicPreferredBloodGlucose).toContainText('mg/dL');
+        });
+      },
+    );
   });
 });

--- a/tests/fixtures/clinic-helpers.ts
+++ b/tests/fixtures/clinic-helpers.ts
@@ -1,19 +1,11 @@
 import { test as base } from '@fixtures/base';
 import type { Page } from '@playwright/test';
-import ClinicianNav from '../../page-objects/clinician/ClinicianNavigation';
+import ClinicianNav, {
+  WORKSPACE_NAMES,
+  WorkspaceKey,
+} from '../../page-objects/clinician/ClinicianNavigation';
 import ClinicianDashboardPage from '../../page-objects/clinician/ClinicianDashboardPage';
 import AccountNav from '../../page-objects/account/AccountNavigation';
-
-// Type definitions for workspace keys (matching the page object)
-export type WorkspaceKey =
-  | 'AdminClinicBase'
-  | 'AdminClinicEnterprise'
-  | 'MemberClinicBase'
-  | 'MemberClinicEnterprise'
-  | 'NonMemberClinicBase'
-  | 'NonMemberClinicEnterprise'
-  | 'PartnerClinicBase'
-  | 'PartnerClinicEnterprise';
 
 // Type definitions for page keys (matching the page object)
 export type PageKey =
@@ -23,22 +15,9 @@ export type PageKey =
   | 'Profile'
   | 'ProfileEdit';
 
-/**
- * Initialize clinician navigation helpers after login
- */
-async function setupClinicianSession(page: Page): Promise<ClinicianNav> {
-  // Wait for clinician navigation to be available
-  const nav = new ClinicianNav(page);
-
-  // Navigate to login and setup clinic session if needed
-  if (!page.url().includes('clinic-workspace')) {
-    await page.goto('/login');
-    await navigateToWorkspaceSelection(page);
-  }
-
-  console.log('🏥 Clinic session setup complete');
-  return nav;
-}
+export const ALL_WORKSPACE_KEYS: WorkspaceKey[] = WORKSPACE_NAMES.map(name =>
+  name.replace(/[^a-zA-Z0-9]/g, ''),
+);
 
 /**
  * Navigate to workspace selection page
@@ -59,6 +38,23 @@ async function navigateToWorkspaceSelection(page: Page): Promise<void> {
   });
 
   // console.log('✅ Navigated to workspace selection page');
+}
+
+/**
+ * Initialize clinician navigation helpers after login
+ */
+async function setupClinicianSession(page: Page): Promise<ClinicianNav> {
+  // Wait for clinician navigation to be available
+  const nav = new ClinicianNav(page);
+
+  // Navigate to login and setup clinic session if needed
+  if (!page.url().includes('clinic-workspace')) {
+    await page.goto('/login');
+    await navigateToWorkspaceSelection(page);
+  }
+
+  console.log('🏥 Clinic session setup complete');
+  return nav;
 }
 
 /**
@@ -175,6 +171,47 @@ async function executeAcrossWorkspaces(
 }
 
 /**
+ * Find and access any available patient (fastest option)
+ * @param page - The Playwright page object
+ * @returns The full name of the first patient that was accessed
+ */
+async function findAndAccessAnyPatient(page: Page): Promise<string> {
+  const dashboard = new ClinicianDashboardPage(page);
+
+  try {
+    // Clear search to show all patients
+    await dashboard.searchInput.click();
+    await dashboard.searchInput.fill(' ');
+    await page.waitForTimeout(500);
+    await dashboard.searchInput.fill('');
+    await page.waitForTimeout(1500);
+
+    let allCells = await dashboard.patientListTable.getByRole('cell').all();
+
+    // If no cells, try pressing Enter on empty search
+    if (allCells.length === 0) {
+      await dashboard.searchInput.press('Enter');
+      await page.waitForTimeout(1500);
+      allCells = await dashboard.patientListTable.getByRole('cell').all();
+    }
+
+    // Find the first cell that looks like a patient name
+    for (const cell of allCells) {
+      const cellText = await cell.textContent();
+      if (cellText && cellText.trim().length > 3 && cellText.includes(' ')) {
+        await cell.click();
+        await page.waitForTimeout(800);
+        return cellText.trim();
+      }
+    }
+
+    throw new Error('No patient names found in table');
+  } catch (error) {
+    throw new Error(`Failed to find any patient: ${error}`);
+  }
+}
+
+/**
  * Find and access any patient whose name contains the search term (optimized version)
  * @param searchTerm - Partial name to search for (e.g., "Custodial")
  * @param page - The Playwright page object
@@ -182,11 +219,6 @@ async function executeAcrossWorkspaces(
  */
 async function findAndAccessPatientByPartialName(searchTerm: string, page: Page): Promise<string> {
   const dashboard = new ClinicianDashboardPage(page);
-
-  // If empty search term, find any available patient
-  if (!searchTerm || searchTerm.trim() === '') {
-    return findAndAccessAnyPatient(page);
-  }
 
   // Strategy 1: Fill search field THEN click Show All (proven fastest method)
   try {
@@ -243,47 +275,6 @@ async function findAndAccessPatientByPartialName(searchTerm: string, page: Page)
     throw new Error(
       `No patient found containing "${searchTerm}" and no fallback patients available`,
     );
-  }
-}
-
-/**
- * Find and access any available patient (fastest option)
- * @param page - The Playwright page object
- * @returns The full name of the first patient that was accessed
- */
-async function findAndAccessAnyPatient(page: Page): Promise<string> {
-  const dashboard = new ClinicianDashboardPage(page);
-
-  try {
-    // Clear search to show all patients
-    await dashboard.searchInput.click();
-    await dashboard.searchInput.fill(' ');
-    await page.waitForTimeout(500);
-    await dashboard.searchInput.fill('');
-    await page.waitForTimeout(1500);
-
-    let allCells = await dashboard.patientListTable.getByRole('cell').all();
-
-    // If no cells, try pressing Enter on empty search
-    if (allCells.length === 0) {
-      await dashboard.searchInput.press('Enter');
-      await page.waitForTimeout(1500);
-      allCells = await dashboard.patientListTable.getByRole('cell').all();
-    }
-
-    // Find the first cell that looks like a patient name
-    for (const cell of allCells) {
-      const cellText = await cell.textContent();
-      if (cellText && cellText.trim().length > 3 && cellText.includes(' ')) {
-        await cell.click();
-        await page.waitForTimeout(800);
-        return cellText.trim();
-      }
-    }
-
-    throw new Error('No patient names found in table');
-  } catch (error) {
-    throw new Error(`Failed to find any patient: ${error}`);
   }
 }
 


### PR DESCRIPTION
- Refactored ClinicianNavigation to use dynamic workspace keys and unified navigation interface. 

- Updated WorkspaceSettingsPage for more granular selectors and improved structure. 

- Enhanced the edit-clinic-address test to cover all workspace types, including admin and member permissions, and expanded test coverage to edit and reset all workspace details. 

- Cleaned up and improved helper utilities for workspace and patient navigation.

- eslint performed on all changed scripts and all test pass without issues.