### PR TITLE
Capture & delete created clinic in tests

### DIFF
--- a/page-objects/clinician/WorkspacesPage.ts
+++ b/page-objects/clinician/WorkspacesPage.ts
@@ -28,6 +28,20 @@ export default class WorkspacesPage {
     await this.page.goto(this.url);
   }
 
+  /**
+   * Wait until the workspaces list has fully rendered: the heading is present, at least one
+   * workspace card has painted, and the network has settled. Load-state based (no fixed delay) —
+   * useful before asserting on the list or capturing an evidence screenshot so the screen is
+   * fully loaded. Assumes the account has at least one workspace.
+   */
+  async waitUntilLoaded(): Promise<void> {
+    await this.header.waitFor({ state: 'visible' });
+    await this.page.getByRole('button', { name: 'Go To Workspace' }).first().waitFor({
+      state: 'visible',
+    });
+    await this.page.waitForLoadState('networkidle');
+  }
+
   async visitFirstClinic(): Promise<void> {
     await this.page.getByRole('button', { name: 'Go To Workspace' }).first().click();
   }

--- a/tests/clinician/Clinician-CreateClinicWorkspace.spec.ts
+++ b/tests/clinician/Clinician-CreateClinicWorkspace.spec.ts
@@ -2,6 +2,8 @@ import WorkspacesPage from '@pom/clinician/WorkspacesPage';
 import ClinicCreationPage from '@pom/clinician/ClinicCreationPage';
 import { expect } from '../fixtures/base';
 import { test } from '../fixtures/clinic-helpers';
+import { createNetworkHelper } from '../fixtures/network-helpers';
+import env from '../../utilities/env';
 
 import { TEST_TAGS, createValidatedTags } from '../fixtures/test-tags';
 
@@ -15,6 +17,12 @@ test.describe('Clinic Account may create a new workspace', () => {
       tag: createValidatedTags([TEST_TAGS.CLINICIAN, TEST_TAGS.UI, TEST_TAGS.HIGH]),
     },
     async ({ page }) => {
+      // Start capturing the clinic-creation API call up front (before the form is submitted) so
+      // the workspace it creates can be deleted afterwards. See the "When the workspace is
+      // deleted" step below.
+      const api = createNetworkHelper(page);
+      api.captureClinicCreation();
+
       // Step 1: Login as clinician
       await test.step(
         'Given a clinician with multiple workspaces is logged in',
@@ -44,7 +52,7 @@ test.describe('Clinic Account may create a new workspace', () => {
 
       // Step 3: Confirm create page exists and is rached.
       await test.step(
-        'Then the user navigates to the create patient page',
+        'Then the user navigates to the create clinic page',
         async () => {
           await expect(page).toHaveURL(/clinic-details\/new/);
           await expect(clinicCreationPage.pageHeader).toBeVisible();
@@ -136,6 +144,58 @@ test.describe('Clinic Account may create a new workspace', () => {
         },
         { detail: 'Confirm a card for the newly created clinic appears on the workspaces screen.' },
       );
+
+      // Steps 11-12: delete the workspace this test created and confirm it's gone. These run as
+      // cleanup steps so they ALWAYS execute — even if an assertion above failed — keeping the
+      // account free of "Test Clinic ..." bloat on re-runs, while still rendering as normal
+      // When/Then steps in Xray. Deletion is done via the clinic API; the UI check in the "Then"
+      // step is the source of truth — if it can't confirm the workspace is gone, the test fails
+      // (see the assertion after the steps).
+      let workspaceConfirmedDeleted = false;
+
+      await test.cleanupStep(
+        'When the workspace is deleted',
+        async () => {
+          await api.deleteCreatedClinic(env.BASE_URL);
+        },
+        {
+          detail:
+            'Delete the workspace created earlier in this test. Automated run: send an ' +
+            'authenticated DELETE to /v1/clinics/{clinicId}, reusing the same ' +
+            'x-tidepool-session-token the app sent when it created the clinic. While executing ' +
+            'the test manually, utilize ORCA to delete the workspace.',
+        },
+      );
+
+      await test.cleanupStep(
+        'Then the workspace no longer displays within the workspaces page',
+        async () => {
+          // Reload the workspaces page and wait for it to fully render (load-state based, not a
+          // fixed delay) so the step's evidence screenshot shows the loaded page minus the
+          // deleted workspace. Then confirm the clinic card is gone — the authoritative
+          // confirmation of deletion.
+          await workspacesPage.goto();
+          await workspacesPage.waitUntilLoaded();
+
+          await expect(workspacesPage.getClinicCard(clinicName)).not.toBeVisible();
+          workspaceConfirmedDeleted = true;
+        },
+        {
+          detail:
+            'Reload the Clinic Workspaces page and confirm the card for the deleted clinic no ' +
+            'longer appears in the workspaces list.',
+        },
+      );
+
+      // Fail the test if the UI could not confirm the workspace was deleted. The "Then" cleanup
+      // step above is already recorded as FAILED for Xray on its own, but cleanupStep swallows
+      // the error so sibling cleanups can still run; this assertion propagates that failure to
+      // the overall test result.
+      expect(
+        workspaceConfirmedDeleted,
+        'Workspace still appears in the workspaces list after deletion — the UI could not ' +
+          'confirm the workspace was deleted.',
+      ).toBe(true);
     },
   );
 });

--- a/tests/fixtures/base.ts
+++ b/tests/fixtures/base.ts
@@ -190,17 +190,59 @@ export const test = base.extend<CustomFixtures>({
         (globalThis as any).stepCounter?.increment?.();
         return originalStep.call(this, name, async (stepInfo: TestStepInfo) => {
           const startTime = Date.now();
+
+          // Run the body, capturing any error so we can STILL screenshot the end state (pass OR
+          // fail) before recording. Cleanup steps run the raw Playwright step and thus bypass
+          // the stepScreenshoter wrapper, so without this they'd produce no evidence at all.
+          let result: T | undefined;
+          let failed = false;
+          let cleanupError: unknown;
           try {
-            const result = await fn(stepInfo);
-            recordStep(name, Date.now() - startTime, 'passed', options?.detail);
-            return result;
+            result = await fn(stepInfo);
           } catch (error) {
-            recordStep(name, Date.now() - startTime, 'failed', options?.detail);
+            failed = true;
+            cleanupError = error;
+          }
+          const duration = Date.now() - startTime;
+
+          // Take a screenshot for this cleanup step (unless it opts out), named with the step's
+          // ordinal so the Xray reporter maps it to this step (it matches attachments by the
+          // `step-NN` filename prefix). Mirrors the stepScreenshoter fixture's capture/attach.
+          if (!name.includes('[no-screenshot]')) {
+            try {
+              if (!page.isClosed()) {
+                const ordinal = (globalThis as any).stepCounter?.get?.() ?? 0;
+                const cleanName = name.replace(/\s*\[no-screenshot\]\s*/g, '').trim();
+                const screenshotName = `step-${ordinal
+                  .toString()
+                  .padStart(2, '0')}-${cleanName.toLowerCase().replace(/[^a-z0-9]/g, '-')}.png`;
+                const screenshot = await page.screenshot({ fullPage: true });
+                if (testInfo && typeof testInfo.attach === 'function') {
+                  await testInfo.attach(screenshotName, {
+                    body: screenshot,
+                    contentType: 'image/png',
+                  });
+                  const testResultsDir = path.join(testInfo.outputDir, 'attachments');
+                  await fs.promises.mkdir(testResultsDir, { recursive: true });
+                  await fs.promises.writeFile(
+                    path.join(testResultsDir, screenshotName),
+                    screenshot,
+                  );
+                }
+              }
+            } catch {
+              // Screenshot capture failed; continue without evidence.
+            }
+          }
+
+          recordStep(name, duration, failed ? 'failed' : 'passed', options?.detail);
+          if (failed) {
             // A cleanup failure must not abort the remaining cleanups; surface it in logs
             // but don't re-throw (the primary failure, if any, still fails the test).
-            console.error(`[cleanup] step failed (continuing): ${name}`, error);
+            console.error(`[cleanup] step failed (continuing): ${name}`, cleanupError);
             return undefined as unknown as T;
           }
+          return result as T;
         });
       };
 

--- a/tests/fixtures/network-helpers.ts
+++ b/tests/fixtures/network-helpers.ts
@@ -55,7 +55,10 @@ export class NetworkHelper {
    * test; if the create call is never seen, deleteCreatedClinic() reports the missing data.
    */
   captureClinicCreation(): void {
-    this.page.on('response', async (response: Response) => {
+    // If we've already captured the created clinic, don't register another listener.
+    if (this.clinicCreation.clinicId) return;
+
+    const handler = async (response: Response) => {
       try {
         const request = response.request();
         if (request.method() === 'POST' && /\/v1\/clinics(\?.*)?$/.test(response.url())) {
@@ -67,11 +70,16 @@ export class NetworkHelper {
             `🏥 Captured clinic create: id=${this.clinicCreation.clinicId ?? 'UNKNOWN'} ` +
               `(POST ${response.url()} -> ${response.status()})`,
           );
+
+          // Stop listening once we've seen the create response.
+          this.page.off('response', handler);
         }
       } catch {
         // Never let capture break the test; deleteCreatedClinic() reports missing data instead.
       }
-    });
+    };
+
+    this.page.on('response', handler);
   }
 
   /** The clinic id captured by {@link captureClinicCreation}, if the create call was seen. */

--- a/tests/fixtures/network-helpers.ts
+++ b/tests/fixtures/network-helpers.ts
@@ -16,6 +16,14 @@ export interface NetworkCapture {
   timestamp: number;
 }
 
+export interface ClinicCreationCapture {
+  // The id the clinic service assigns to the newly created workspace.
+  clinicId?: string;
+  // The headers the app sent on the create call (incl. x-tidepool-session-token), replayed on
+  // the DELETE so cleanup authenticates exactly as the app does.
+  authHeaders: Record<string, string>;
+}
+
 const ENDPOINTS = {
   profile: /\/data\/[^\/]+$/, // GET requests for patient data
   profileUpdate: /\/data\/[^\/]+$/, // PUT requests for patient data updates
@@ -33,8 +41,87 @@ export class NetworkHelper {
 
   private isCapturing = false;
 
+  private clinicCreation: ClinicCreationCapture = { authHeaders: {} };
+
   constructor(page: Page) {
     this.page = page;
+  }
+
+  /**
+   * Start listening for the clinic-creation POST (/v1/clinics) so the workspace it creates can
+   * later be deleted via {@link deleteCreatedClinic}. Call this BEFORE submitting the
+   * create-clinic form. Captures the new clinic's id from the response and the auth headers the
+   * app sent (incl. x-tidepool-session-token). Passive by design — it never throws or fails the
+   * test; if the create call is never seen, deleteCreatedClinic() reports the missing data.
+   */
+  captureClinicCreation(): void {
+    this.page.on('response', async (response: Response) => {
+      try {
+        const request = response.request();
+        if (request.method() === 'POST' && /\/v1\/clinics(\?.*)?$/.test(response.url())) {
+          this.clinicCreation.authHeaders = await request.allHeaders();
+          const body = await response.json().catch(() => undefined);
+          this.clinicCreation.clinicId =
+            body?.id ?? body?.clinicId ?? body?.clinic?.id ?? this.clinicCreation.clinicId;
+          console.log(
+            `🏥 Captured clinic create: id=${this.clinicCreation.clinicId ?? 'UNKNOWN'} ` +
+              `(POST ${response.url()} -> ${response.status()})`,
+          );
+        }
+      } catch {
+        // Never let capture break the test; deleteCreatedClinic() reports missing data instead.
+      }
+    });
+  }
+
+  /** The clinic id captured by {@link captureClinicCreation}, if the create call was seen. */
+  getCreatedClinicId(): string | undefined {
+    return this.clinicCreation.clinicId;
+  }
+
+  /**
+   * Delete the clinic workspace captured by {@link captureClinicCreation} via the clinic API,
+   * reusing the auth header the app sent on the create call. Throws with a clear message if the
+   * clinic id or an auth header was never captured, or if the API responds with a non-2xx status.
+   * @param baseUrl - The environment host (e.g. env.BASE_URL); DELETE hits {baseUrl}/v1/clinics/{id}.
+   * @returns The HTTP status code of the DELETE response.
+   */
+  async deleteCreatedClinic(baseUrl: string): Promise<number> {
+    const { clinicId, authHeaders } = this.clinicCreation;
+    if (!clinicId) {
+      throw new Error(
+        'No clinic id was captured from the create-clinic response; cannot delete the workspace. ' +
+          'Call captureClinicCreation() before submitting the form, and check that creating a ' +
+          'clinic still POSTs to /v1/clinics.',
+      );
+    }
+
+    const sessionToken = authHeaders['x-tidepool-session-token'];
+    const { authorization } = authHeaders;
+    if (!sessionToken && !authorization) {
+      throw new Error(
+        'No auth header (x-tidepool-session-token / authorization) was captured from the create ' +
+          'request; cannot authenticate the delete.',
+      );
+    }
+
+    const deleteHeaders: Record<string, string> = {};
+    if (sessionToken) deleteHeaders['x-tidepool-session-token'] = sessionToken;
+    if (authorization) deleteHeaders.authorization = authorization;
+
+    // baseUrl is the real environment host (e.g. https://qa2.development.tidepool.org); the
+    // clinic service lives on that same host at /v1/clinics/{clinicId}.
+    const deleteUrl = `${baseUrl.replace(/\/$/, '')}/v1/clinics/${clinicId}`;
+    const response = await this.page.request.delete(deleteUrl, { headers: deleteHeaders });
+
+    console.log(`🗑️  DELETE ${deleteUrl} -> ${response.status()}`);
+    if (!response.ok()) {
+      const bodyText = await response.text().catch(() => '');
+      throw new Error(
+        `Expected clinic deletion to succeed but got HTTP ${response.status()}: ${bodyText}`,
+      );
+    }
+    return response.status();
   }
 
   async startCapture(): Promise<void> {


### PR DESCRIPTION
Add end-to-end support for capturing a created clinic and cleaning it up after the test. Key changes:

- page-objects/clinician/WorkspacesPage.ts: add waitUntilLoaded() to wait for header, first workspace card button, and network idle before asserting or taking evidence screenshots.
- tests/clinician/Clinician-CreateClinicWorkspace.spec.ts: start capturing the clinic-creation POST before submitting the form, add cleanup steps that call the API to delete the created clinic, reload the workspaces page, wait until loaded, and assert the clinic card is gone; fail the test if the UI cannot confirm deletion.
- tests/fixtures/network-helpers.ts: introduce ClinicCreationCapture and methods captureClinicCreation(), getCreatedClinicId(), and deleteCreatedClinic(baseUrl) to record the create response (clinic id and auth headers) and perform an authenticated DELETE against /v1/clinics/{id}.
- tests/fixtures/base.ts: enhance the custom step wrapper to capture cleanup step errors, always take an evidence screenshot (unless opted out), attach/save it to test output, record step results, and avoid aborting sibling cleanup steps while surfacing failures in logs.

These changes improve test hygiene by removing test-created workspaces automatically, increase stability of UI assertions by waiting for load states, and provide evidence for cleanup steps.